### PR TITLE
fix abort of stream read to avoid to short tracks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,6 @@ zs_config.json
 
 # MacOS file
 .DS_Store
+
+# backup
+*.bak

--- a/zspotify/const.py
+++ b/zspotify/const.py
@@ -28,6 +28,8 @@ ARTWORK = 'artwork'
 
 TRACKS = 'tracks'
 
+TOTAL_TRACKS = 'total_tracks'
+
 TRACK = 'track'
 
 ITEMS = 'items'
@@ -37,6 +39,12 @@ NAME = 'name'
 HREF = 'href'
 
 ID = 'id'
+
+ISRC = 'isrc'
+
+EXTERNAL_IDS = 'external_ids'
+
+COMMENT = 'comment'
 
 URL = 'url'
 

--- a/zspotify/podcast.py
+++ b/zspotify/podcast.py
@@ -118,8 +118,10 @@ def download_episode(episode_id) -> None:
                 unit_divisor=1024
             ) as p_bar:
                 prepare_download_loader.stop()
-                for _ in range(int(total_size / ZSpotify.CONFIG.get_chunk_size()) + 1):
+                last_read = 1
+                while(downloaded < total_size and last_read):
                     data = stream.input_stream.stream().read(ZSpotify.CONFIG.get_chunk_size())
+                    last_read = len(data)
                     p_bar.update(file.write(data))
                     downloaded += len(data)
                     if ZSpotify.CONFIG.get_download_real_time():

--- a/zspotify/track.py
+++ b/zspotify/track.py
@@ -45,7 +45,6 @@ def get_song_info(song_id) -> Tuple[List[str], List[Any], str, str, Any, Any, An
         raise ValueError(f'Invalid response from TRACKS_URL:\n{raw}')
 
     try:
-        print(info)
         artists = []
         for data in info[TRACKS][0][ARTISTS]:
             artists.append(data[NAME])

--- a/zspotify/track.py
+++ b/zspotify/track.py
@@ -9,7 +9,8 @@ from librespot.metadata import TrackId
 from ffmpy import FFmpeg
 
 from const import TRACKS, ALBUM, GENRES, NAME, ITEMS, DISC_NUMBER, TRACK_NUMBER, IS_PLAYABLE, ARTISTS, IMAGES, URL, \
-    RELEASE_DATE, ID, TRACKS_URL, SAVED_TRACKS_URL, TRACK_STATS_URL, CODEC_MAP, EXT_MAP, DURATION_MS, HREF
+    RELEASE_DATE, ID, TRACKS_URL, SAVED_TRACKS_URL, TRACK_STATS_URL, CODEC_MAP, EXT_MAP, DURATION_MS, HREF, ISRC, \
+    EXTERNAL_IDS, TOTAL_TRACKS
 from termoutput import Printer, PrintChannel
 from utils import fix_filename, set_audio_tags, set_music_thumbnail, create_download_directory, \
     get_directory_song_ids, add_to_directory_song_ids, get_previously_downloaded, add_to_archive, fmt_seconds
@@ -35,7 +36,7 @@ def get_saved_tracks() -> list:
     return songs
 
 
-def get_song_info(song_id) -> Tuple[List[str], List[Any], str, str, Any, Any, Any, Any, Any, Any, int]:
+def get_song_info(song_id) -> Tuple[List[str], List[Any], str, str, Any, Any, Any, Any, Any, Any, Any, Any, int]:
     """ Retrieves metadata for downloaded songs """
     with Loader(PrintChannel.PROGRESS_INFO, "Fetching track information..."):
         (raw, info) = ZSpotify.invoke_url(f'{TRACKS_URL}?ids={song_id}&market=from_token')
@@ -44,6 +45,7 @@ def get_song_info(song_id) -> Tuple[List[str], List[Any], str, str, Any, Any, An
         raise ValueError(f'Invalid response from TRACKS_URL:\n{raw}')
 
     try:
+        print(info)
         artists = []
         for data in info[TRACKS][0][ARTISTS]:
             artists.append(data[NAME])
@@ -54,11 +56,13 @@ def get_song_info(song_id) -> Tuple[List[str], List[Any], str, str, Any, Any, An
         release_year = info[TRACKS][0][ALBUM][RELEASE_DATE].split('-')[0]
         disc_number = info[TRACKS][0][DISC_NUMBER]
         track_number = info[TRACKS][0][TRACK_NUMBER]
+        total_tracks = info[TRACKS][0][ALBUM][TOTAL_TRACKS]
         scraped_song_id = info[TRACKS][0][ID]
         is_playable = info[TRACKS][0][IS_PLAYABLE]
         duration_ms = info[TRACKS][0][DURATION_MS]
-
-        return artists, info[TRACKS][0][ARTISTS], album_name, name, image_url, release_year, disc_number, track_number, scraped_song_id, is_playable, duration_ms
+        isrc = info[TRACKS][0][EXTERNAL_IDS][ISRC]
+        
+        return artists, info[TRACKS][0][ARTISTS], album_name, name, image_url, release_year, disc_number, track_number, total_tracks, scraped_song_id, is_playable, duration_ms, isrc
     except Exception as e:
         raise ValueError(f'Failed to parse TRACKS_URL response: {str(e)}\n{raw}')
 
@@ -117,7 +121,7 @@ def download_track(mode: str, track_id: str, extra_keys=None, disable_progressba
         output_template = ZSpotify.CONFIG.get_output(mode)
 
         (artists, raw_artists, album_name, name, image_url, release_year, disc_number,
-         track_number, scraped_song_id, is_playable, duration_ms) = get_song_info(track_id)
+         track_number, total_tracks, scraped_song_id, is_playable, duration_ms, isrc) = get_song_info(track_id)
 
         song_name = fix_filename(artists[0]) + ' - ' + fix_filename(name)
 
@@ -216,7 +220,7 @@ def download_track(mode: str, track_id: str, extra_keys=None, disable_progressba
                     genres = get_song_genres(raw_artists, name)
 
                     convert_audio_format(filename_temp)
-                    set_audio_tags(filename_temp, artists, genres, name, album_name, release_year, disc_number, track_number)
+                    set_audio_tags(filename_temp, artists, genres, name, album_name, release_year, disc_number, track_number, total_tracks, isrc, scraped_song_id)
                     set_music_thumbnail(filename_temp, image_url)
 
                     if filename_temp != filename:

--- a/zspotify/track.py
+++ b/zspotify/track.py
@@ -199,8 +199,10 @@ def download_track(mode: str, track_id: str, extra_keys=None, disable_progressba
                             unit_divisor=1024,
                             disable=disable_progressbar
                     ) as p_bar:
-                        for _ in range(int(total_size / ZSpotify.CONFIG.get_chunk_size()) + 1):
+                        last_read = 1
+                        while(downloaded < total_size and last_read):
                             data = stream.input_stream.stream().read(ZSpotify.CONFIG.get_chunk_size())
+                            last_read = len(data)
                             p_bar.update(file.write(data))
                             downloaded += len(data)
                             if ZSpotify.CONFIG.get_download_real_time():

--- a/zspotify/utils.py
+++ b/zspotify/utils.py
@@ -10,8 +10,8 @@ from typing import List, Tuple
 import music_tag
 import requests
 
-from const import ARTIST, GENRE, TRACKTITLE, ALBUM, YEAR, DISCNUMBER, TRACKNUMBER, ARTWORK, \
-    WINDOWS_SYSTEM, ALBUMARTIST
+from const import ARTIST, GENRE, TRACKTITLE, ALBUM, YEAR, DISCNUMBER, TRACKNUMBER, TOTAL_TRACKS, ARTWORK, \
+    WINDOWS_SYSTEM, ALBUMARTIST, ISRC, COMMENT
 from zspotify import ZSpotify
 
 
@@ -124,7 +124,7 @@ def clear() -> None:
         os.system('clear')
 
 
-def set_audio_tags(filename, artists, genres, name, album_name, release_year, disc_number, track_number) -> None:
+def set_audio_tags(filename, artists, genres, name, album_name, release_year, disc_number, track_number, total_tracks, isrc, scraped_song_id) -> None:
     """ sets music_tag metadata """
     tags = music_tag.load_file(filename)
     tags[ALBUMARTIST] = artists[0]
@@ -135,6 +135,9 @@ def set_audio_tags(filename, artists, genres, name, album_name, release_year, di
     tags[YEAR] = release_year
     tags[DISCNUMBER] = disc_number
     tags[TRACKNUMBER] = track_number
+    tags[TOTAL_TRACKS] = total_tracks
+    tags[ISRC] = isrc
+    tags[COMMENT] = scraped_song_id
     tags.save()
 
 


### PR DESCRIPTION
When reading the stream, the entire chunk size is not always read, so the total download size may be too short.