### PR TITLE
Add aif output option to directly convert to a non-compressed format.

### DIFF
--- a/zspotify/const.py
+++ b/zspotify/const.py
@@ -88,6 +88,7 @@ WINDOWS_SYSTEM = 'Windows'
 
 CODEC_MAP = {
     'aac': 'aac',
+    'aif': 'pcm_s16be',
     'fdk_aac': 'libfdk_aac',
     'm4a': 'aac',
     'mp3': 'libmp3lame',
@@ -98,6 +99,7 @@ CODEC_MAP = {
 
 EXT_MAP = {
     'aac': 'm4a',
+    'aif': 'aif',
     'fdk_aac': 'm4a',
     'm4a': 'm4a',
     'mp3': 'mp3',


### PR DESCRIPTION
Added `aif` to the codec and extension map constants so aif can be used by the `DOWNLOAD_FORMAT` setting. When doing so, ffmpeg outputs to pcm and saves in the `aif` format.

I imagine `wav` would also work the same way, for what it's worth.

Using an uncompressed codec allows downloads to end up directly in uncompressed format suitable for use in DAW workflows.